### PR TITLE
docs: flag Klarna Checkout as deprecated in feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Klarna Mobile SDK is the best and only official way to integrate Klarna products
 We offer a seamless and straightforward way to 
 
 * Render individual payment methods through **Klarna Payments**
-* Present a fully-featured checkout through **Klarna Checkout**
+* Present a fully-featured checkout through **Klarna Checkout** ⚠️ *Deprecated — KCO integrations and support have been officially deprecated and will be removed in a future version of the SDK. See [migration guidance](https://docs.kustom.co/contents/checkout/integrate-kco-in-your-mobile/introduction).*
 * Give your customers a running start into the purchasing flow with **On-site Messaging**
 * Let customers quickly and safely sign for your platform using their Klarna account via **Sign in with Klarna**
 


### PR DESCRIPTION
### Description of the pull request
The README's feature list still presents Klarna Checkout as a first-class, non-deprecated feature. However, CHANGELOG.md (v2.12.0, 2026-06-23) states KCO integrations and support have been officially deprecated and will be removed in a future SDK version, with guidance to migrate to Kustom Mobile SDK. This PR adds a deprecation note and migration link next to the Klarna Checkout bullet.

### Motivation and context
A developer skimming only the README (not the changelog) would have no indication that Klarna Checkout via this SDK is being phased out, and might build a new integration against a feature slated for removal.

### How has the change been tested?
Documentation-only change. I verified the Markdown renders correctly and confirmed the deprecation wording matches CHANGELOG.md v2.12.0 exactly.

### Screenshots
N/A. Text-only change.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)